### PR TITLE
fix: allow version numbers in brackets

### DIFF
--- a/src/main/java/cx/cad/keepachangelog/internal/ChangelogExtractor.java
+++ b/src/main/java/cx/cad/keepachangelog/internal/ChangelogExtractor.java
@@ -32,7 +32,7 @@ import java.util.stream.Collectors;
 public class ChangelogExtractor {
 
     public static final String VERSION_AND_DATE_SEPARATOR = " - ";
-    private Document mdNode;
+    private final Document mdNode;
 
     private ChangelogExtractor(Document node) {
         this.mdNode = node;
@@ -93,7 +93,7 @@ public class ChangelogExtractor {
 
         String text = heading.getText().unescape();
         String[] versionAndDate = extractVersionAndDateFromHeadingText(text);
-        String version = versionAndDate[0];
+        String version = versionAndDate[0].replaceAll("[\\[\\]]", "");
         String dateAndYanked = versionAndDate[1];
         boolean wasYanked = dateAndYanked != null && dateAndYanked.contains("[YANKED]");
         String date = dateAndYanked != null ? dateAndYanked.substring(0, ChangelogEntry.EXPECTED_DATE_FORMAT.length()) : null;

--- a/src/test/java/cx/cad/keepachangelog/TestChangelogs.java
+++ b/src/test/java/cx/cad/keepachangelog/TestChangelogs.java
@@ -26,6 +26,7 @@ public class TestChangelogs {
     public static final String BASIC = readTestFile("CHANGELOG-basic.md");
     public static final String UNRELEASED = readTestFile("CHANGELOG-withUnreleased.md");
     public static final String YANKED = readTestFile("CHANGELOG-withYanked.md");
+    public static final String VERSIONS_IN_BRACKETS = readTestFile("CHANGELOG-versionsInBrackets.md");
 
     private static String readTestFile(String testFileName) {
         String filename = listToPath(Arrays.asList(RESOURCES_DIRECTORY, testFileName));

--- a/src/test/java/cx/cad/keepachangelog/VersionInBracketsParseTest.java
+++ b/src/test/java/cx/cad/keepachangelog/VersionInBracketsParseTest.java
@@ -1,0 +1,48 @@
+/*
+  Copyright 2017 Colin Dean
+  <p>
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  <p>
+  http://www.apache.org/licenses/LICENSE-2.0
+  <p>
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package cx.cad.keepachangelog;
+
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class VersionInBracketsParseTest {
+
+    static ChangelogParser parser;
+    static ChangelogData data;
+
+    @BeforeClass
+    static public void setup() {
+        parser = new ChangelogParser();
+        data = parser.parse(TestChangelogs.VERSIONS_IN_BRACKETS);
+    }
+
+    @Test
+    public void test_parser_gets_projectName() {
+        Assert.assertEquals("Changelog", data.getProjectName());
+    }
+
+    @Test
+    public void test_parser_gets_description() {
+        Assert.assertTrue(data.getDescription().contains("semver.org"));
+        Assert.assertTrue(data.getDescription().contains("notable changes"));
+    }
+
+}

--- a/src/test/resources/CHANGELOG-versionsInBrackets.md
+++ b/src/test/resources/CHANGELOG-versionsInBrackets.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
+to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+This example contains version numbers between brackets
+
+## [Unreleased]
+
+### Fixed
+
+- Allow version numbers in brackets
+
+## [1.1.0] - 2019-02-15
+
+### Added
+
+- First feature
+

--- a/src/test/resources/CHANGELOG-versionsInBrackets.md
+++ b/src/test/resources/CHANGELOG-versionsInBrackets.md
@@ -19,3 +19,7 @@ This example contains version numbers between brackets
 
 - First feature
 
+[Unreleased]: https://wwww.example.com/compare/v1.1.0...HEAD
+
+[1.1.0]: https://www.example.com/compare/v1.0.0...v1.1.0
+


### PR DESCRIPTION
The changelog of site _keepachangelog,com_ has, in the current 1.0.0 version, version numbers between brackets, so I guess the parser should allow this format also.
