### PR TITLE
Improve debug for date parsing error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Changed
+
+* Include more details about failures when parsing versions with dates.
+
 ### Removed
 
 * Internal packages are no longer included in documentation.
@@ -55,8 +59,8 @@ This release was yanked because of a deployment problem.
 ### Added
 
 * Initial usable release.
-* Parsing any CHANGELOG.md conforming strictly to the standard but omits an 
-  `Unreleased` entry and does not use the `Yanked` tag should work.  
+* Parsing any CHANGELOG.md conforming strictly to the standard but omits an
+  `Unreleased` entry and does not use the `Yanked` tag should work.
 
 
 <!-- TEMPLATE

--- a/src/main/java/cx/cad/keepachangelog/internal/ChangelogExtractor.java
+++ b/src/main/java/cx/cad/keepachangelog/internal/ChangelogExtractor.java
@@ -107,7 +107,7 @@ public class ChangelogExtractor {
         try {
             builder = builder.version(version).date(date);
         } catch (ParseException e) {
-            throw new MalformedChangelogException(e);
+            throw new MalformedChangelogException(String.format("Error when processing %s", text), e);
         }
 
         Node next = heading.getNext();


### PR DESCRIPTION
this is just a quick work-around for https://github.com/colindean/keepachangelog-parser-java/issues/11 at least to try better understand which entries are complaining about the date