### PR TITLE
Allow endash and emdash in date/version separator

### DIFF
--- a/src/main/java/cx/cad/keepachangelog/internal/ChangelogExtractor.java
+++ b/src/main/java/cx/cad/keepachangelog/internal/ChangelogExtractor.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
 
 public class ChangelogExtractor {
 
-    public static final String VERSION_AND_DATE_SEPARATOR = " - ";
+    public static final String VERSION_AND_DATE_SEPARATOR = " [-–—] ";
     private Document mdNode;
 
     private ChangelogExtractor(Document node) {


### PR DESCRIPTION
This is dumbly made in GitHub's editor and is untested.